### PR TITLE
Fix

### DIFF
--- a/backend/Controllers/Api/ShopsController.cs
+++ b/backend/Controllers/Api/ShopsController.cs
@@ -88,7 +88,7 @@ namespace backend.Controllers;
             }
             var authzResult = await _authz.AuthorizeAsync(
                                 User, // User property from ControllerBase
-                                shop,
+                                existingShop,
                                 new OwnerOnlyRequirement());
             if (!authzResult.Succeeded) {
                 return Forbid();


### PR DESCRIPTION
Previously, authorization was checking Identity user id against the id provided the PATCH data. This would have allowed anyone to update the shop information. With this fix, controller now authorizes against the owner's id stored in our DB.